### PR TITLE
[build] (new) New 'distclean' target to remove RAIN's jar files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,6 +39,12 @@
         <delete dir="bin"/>
     </target>
     <target depends="clean" name="cleanall"/>
+    <target depends="cleanall" name="distclean">
+        <delete file="rain.jar"/>
+        <delete>
+            <fileset dir="workloads" includes="**/*.jar"/>
+        </delete>
+    </target>
     <target depends="build-subprojects,build-project" name="build"/>
     <target name="build-subprojects"/>
     <target depends="init" name="build-project">


### PR DESCRIPTION
Hello,

In RAIN, current build targets don't include the possibility the remove prebuilt jars.
Specifically, both `clean` and `cleanall` targets only remove the `'bin` directory.

So, I've added the `distclean` targets that, in addition to calling the `cleanall` target, removes the RAIN's jar files (i.e., the `rain.jar` file as well as the jar files inside the `workloads` directory).

If you find this useful, can you consider to merge this pull request?

Best,

Marco
